### PR TITLE
test : 카카오 로그인 모킹 구현

### DIFF
--- a/src/mocks/handlers.js
+++ b/src/mocks/handlers.js
@@ -21,4 +21,25 @@ export const handlers = [
       { status: 201 }
     );
   }),
+
+  http.post('/api/user/kakao-login', async ({ request }) => {
+    const { code } = await request.json();
+
+    // 코드 검증 로직
+    if (code !== 'valid_code') {
+      return HttpResponse.json({ message: '잘못된 코드' }, { status: 401 });
+    }
+
+    return HttpResponse.json(
+      {
+        access_token: 'mock_access_token',
+      },
+      {
+        status: 200,
+        headers: {
+          'Set-Cookie': `refresh_token=mock_refresh_token; Path=/; HttpOnly; Secure; SameSite=Strict`,
+        },
+      }
+    );
+  }),
 ];


### PR DESCRIPTION
# 🚀요약
카카오 로그인 모킹을 구현했습니다. 

# 📝작업 내용
- [x] 카카오 로그인 모킹 구현

```
 HttpResponse.json(
      {
        access_token: 'mock_access_token',
      },
      {
        status: 200,
        headers: {
          'Set-Cookie': `refresh_token=mock_refresh_token; Path=/; HttpOnly; Secure; SameSite=Strict`,
        },
      }
    )
```
일단은 유저 관련은 빼고 진행했습니다. 차후에 `response` 양식 나오면 수정하겠습니당
# 🎸기타 (연관 이슈)

close #2
