### PR TITLE
feat: TaskCard 컴포넌트 및 레이아웃 추가

### DIFF
--- a/src/styles/utility/card.css
+++ b/src/styles/utility/card.css
@@ -1,0 +1,5 @@
+@layer utilities {
+  .shadow-card-shadow {
+    box-shadow: 0px 0px 20px 0px rgba(52, 35, 101, 0.05);
+  }
+}

--- a/src/styles/utility/index.css
+++ b/src/styles/utility/index.css
@@ -1,1 +1,2 @@
 @import './font.css';
+@import './card.css';

--- a/src/task/components/TaskCard/TaskCard.stories.tsx
+++ b/src/task/components/TaskCard/TaskCard.stories.tsx
@@ -7,7 +7,7 @@ import TaskCard from './TaskCard';
 const baseTask: Task = {
   taskId: '123',
   taskNo: 1,
-  content: '매일 아침 산책하기',
+  content: '베리어블 1강 듣기',
   priority: '중요',
   taskDate: '2025-07-20',
   startTime: '06:30:00',
@@ -23,12 +23,15 @@ const meta: Meta<typeof TaskCard> = {
   component: TaskCard,
   tags: ['autodocs'],
   argTypes: {
-    state: {
+    layout: {
       control: { type: 'radio' },
-      options: ['default', 'hover', 'press', 'complete'],
+      options: ['square', 'rectangle', 'timeline'],
     },
-    layout: { control: { type: 'radio' }, options: ['square', 'rectangle'] },
-    size: { control: { type: 'radio' }, options: ['L', 'S'] },
+    size: {
+      control: { type: 'radio' },
+      options: ['L', 'S'],
+      if: { arg: 'layout', eq: 'square' }, // rectangle 이면 감춤
+    },
   },
 };
 
@@ -39,7 +42,6 @@ type Story = StoryObj<typeof TaskCard>;
 export const Default: Story = {
   args: {
     task: baseTask,
-    state: 'default',
     layout: 'square',
     size: 'L',
   },
@@ -60,7 +62,7 @@ export const StatesGallery: Story = {
       }}
     >
       {(['default', 'hover', 'press', 'complete'] as const).map((state) => (
-        <TaskCard key={state} {...args} state={state} />
+        <TaskCard key={state} {...args} />
       ))}
     </div>
   ),

--- a/src/task/components/TaskCard/TaskCard.tsx
+++ b/src/task/components/TaskCard/TaskCard.tsx
@@ -1,0 +1,15 @@
+import RectangleTaskCard from './layouts/RectangleTaskCard';
+import SquareTaskCard from './layouts/SquareTaskCard';
+import TimelineTaskCard from './layouts/TimelineTaskCard';
+import { TaskCardProps } from './TaskCard.types';
+
+export default function TaskCard({ task, layout }: TaskCardProps) {
+  switch (layout) {
+    case 'rectangle':
+      return <RectangleTaskCard task={task} layout={layout} />;
+    case 'timeline':
+      return <TimelineTaskCard task={task} layout={layout} />;
+    case 'square':
+      return <SquareTaskCard task={task} layout={layout} />;
+  }
+}

--- a/src/task/components/TaskCard/TaskCard.types.ts
+++ b/src/task/components/TaskCard/TaskCard.types.ts
@@ -1,0 +1,10 @@
+import { Task } from '@/mocks/todoMockData/todos';
+
+type TaskLayoutType = 'square' | 'rectangle' | 'timeline';
+type TaskCardSize = 'L' | 'S';
+
+export type TaskCardProps = {
+  task: Task;
+  layout: TaskLayoutType;
+  size?: TaskCardSize;
+};

--- a/src/task/components/TaskCard/layouts/RectangleTaskCard.tsx
+++ b/src/task/components/TaskCard/layouts/RectangleTaskCard.tsx
@@ -1,0 +1,29 @@
+import BaseCard from '../../common/Card/BaseCard';
+import CheckIcon from '../../common/icons/checkIcon/CheckIcon';
+import MemoIcon from '../../common/icons/memoIcon/MemoIcon';
+import LabelPriority from '../../common/LabelPriority/LabelPriority';
+import { TaskCardProps } from '../TaskCard.types';
+
+export default function RectangleTaskCard({ task, layout = 'rectangle' }: TaskCardProps) {
+  const { content, priority, goal, isDone } = task;
+  return (
+    <BaseCard layout={layout}>
+      <div className='flex items-start gap-1.5 self-stretch'>
+        <div className='flex flex-col items-start gap-1.5 grow shrink-0 basis-0 '>
+          <div className='text-gray-900 font-body2-medium-tight'>{content}</div>
+          <div className='text-gray-400 font-caption-medium'>{goal}</div>
+        </div>
+        <div className='flex items-center gap-5'>
+          <MemoIcon active='on' />
+          <CheckIcon state={isDone ? 'on' : 'off'} size='L' />
+        </div>
+      </div>
+      <div className='flex items-start gap-3 self-stretch'>
+        <div className='flex items-center self-stretch'>
+          <LabelPriority priority={priority} size='S' />
+          <div className='font-caption-medium text-gray-500'>・매일</div>
+        </div>
+      </div>
+    </BaseCard>
+  );
+}

--- a/src/task/components/TaskCard/layouts/SquareTaskCard.tsx
+++ b/src/task/components/TaskCard/layouts/SquareTaskCard.tsx
@@ -1,43 +1,29 @@
-import { Task } from '@/mocks/todoMockData/todos';
-
+import BaseCard from '../../common/Card/BaseCard';
 import CheckIcon from '../../common/icons/checkIcon/CheckIcon';
 import MemoIcon from '../../common/icons/memoIcon/MemoIcon';
 import LabelPriority from '../../common/LabelPriority/LabelPriority';
+import { TaskCardProps } from '../TaskCard.types';
 
-type TaskCardState = 'default' | 'hover' | 'press' | 'complete';
-type TaskCardLayout = 'square' | 'rectangle';
-type TaskCardSize = 'L' | 'S';
-
-interface TaskCardProps {
-  task: Task;
-  state: TaskCardState;
-  layout: TaskCardLayout;
-  size: TaskCardSize;
-}
-
-export default function TaskCard({ task, size }: TaskCardProps) {
-  const { content, priority, goal } = task;
-
-  // content class
-  // 상위 div class
+export default function SquareTaskCard({ task, layout = 'square' }: TaskCardProps) {
+  const { content, priority, goal, isDone } = task;
 
   return (
-    <div className='flex w-[184px] h-[180px] pt-6 p-5 flex-col justify-between items-center shrink-0 rounded-3xl bg-white shadow-[0_0_20px_0_rgba(52,35,101,0.05)]'>
+    <BaseCard layout={layout}>
       <div className='flex flex-col items-start gap-1 self-stretch'>
         <div className='text-gray-900 font-sans font-medium text-base leading-[normal] tracking-[-0.32px] self-stretch'>{content}</div>
         <div className='font-caption-medium text-gray-400 self-stretch'>{goal}</div>
       </div>
       <div className='flex flex-col items-center gap-2 self-stretch'>
         <div className='flex items-center self-stretch'>
-          <LabelPriority priority={priority} size={size} />
+          <LabelPriority priority={priority} size='S' />
           <div className='font-caption-medium text-gray-500'>・매일</div>
         </div>
         <div className='w-[156px] h-[1px] bg-gray-100'></div>
         <div className='flex justify-between items-center self-stretch'>
-          <MemoIcon active='on' />
-          <CheckIcon size={size} />
+          <MemoIcon active='on' /> {/* TODO: hooks */}
+          <CheckIcon state={isDone ? 'on' : 'off'} size='L' /> {/* TODO:hooks */}
         </div>
       </div>
-    </div>
+    </BaseCard>
   );
 }

--- a/src/task/components/TaskCard/layouts/TimelineTaskCard.tsx
+++ b/src/task/components/TaskCard/layouts/TimelineTaskCard.tsx
@@ -1,0 +1,32 @@
+import BaseCard from '../../common/Card/BaseCard';
+import CheckIcon from '../../common/icons/checkIcon/CheckIcon';
+import MemoIcon from '../../common/icons/memoIcon/MemoIcon';
+import LabelPriority from '../../common/LabelPriority/LabelPriority';
+import { TaskCardProps } from '../TaskCard.types';
+
+export default function TimelineTaskCard({ task, layout = 'timeline' }: TaskCardProps) {
+  const { content, goal, isDone, priority } = task;
+  return (
+    <BaseCard layout={layout}>
+      <div className='flex flex-col items-start gap-2 self-stretch'>
+        <div className='flex flex-col items-start gap-3 self-stretch'>
+          <div className='flex items-start gap-1.5 self-stretch'>
+            <div className='flex flex-col items-start gap-1.5 grow shrink-0 basis-0'>
+              <div className='text-gray-900 font-body2-semibold'>{content}</div>
+              <div className='text-gray-400 font-caption-medium'>{goal}</div>
+            </div>
+            <CheckIcon state={isDone ? 'on' : 'off'} size='L' /> {/* TODO:hooks */}
+          </div>
+          <div className='w-[146px] h-[1px] bg-gray-100'></div>
+          <div className='flex justify-between items-center self-stretch'>
+            <div className='flex items-center gap-[1px]'>
+              <LabelPriority priority={priority} size='S' />
+              <div className='font-caption-medium text-gray-500'>・매일</div>
+            </div>
+            <MemoIcon active='on' />
+          </div>
+        </div>
+      </div>
+    </BaseCard>
+  );
+}

--- a/src/task/components/common/Card/BaseCard.stories.tsx
+++ b/src/task/components/common/Card/BaseCard.stories.tsx
@@ -1,0 +1,27 @@
+import { Meta, StoryObj } from '@storybook/nextjs-vite';
+
+import BaseCard from './BaseCard';
+
+const meta: Meta<typeof BaseCard> = {
+  title: 'card/BaseCard',
+  component: BaseCard,
+  argTypes: {
+    layout: {
+      control: { type: 'radio' },
+      options: ['square', 'rectangle', 'timeline'],
+    },
+    children: {
+      control: 'text',
+    },
+  },
+  args: {
+    layout: 'square',
+    children: 'Task title',
+  },
+};
+
+export default meta;
+
+export type Story = StoryObj<typeof BaseCard>;
+
+export const TaskCard: Story = {};

--- a/src/task/components/common/Card/BaseCard.tsx
+++ b/src/task/components/common/Card/BaseCard.tsx
@@ -1,0 +1,23 @@
+import { cva, VariantProps } from 'class-variance-authority';
+
+import { cn } from '@/utils/cn';
+
+export const card = cva(
+  'flex flex-col shrink-0 bg-white shadow-card-shadow border border-transparent hover:border hover:border-purple-300 active:opacity-50',
+  {
+    variants: {
+      layout: {
+        square:
+          'w-[166px] h-[156px] p-4 pt-5  rounded-[20px] items-center justify-between  md:w-[184px] md:h-[180px] md:p-5 md:pt-6 md:rounded-3xl',
+        rectangle: ' w-[568px] p-5 items-start gap-4 rounded-[20px]',
+        timeline: 'p-4 pr-3 gap-3 md:p-5 md:pb-4 items-start rounded-3xl',
+      },
+    },
+  }
+);
+
+export type CardVariants = VariantProps<typeof card>;
+
+export default function BaseCard({ layout, children }: CardVariants & { children: React.ReactNode }) {
+  return <div className={cn(card({ layout }))}>{children}</div>;
+}


### PR DESCRIPTION
> 아직 노트 열림/닫힘 , complete(DONE)에 대한 상태처리는 구현하지 않았습니다.

TaskCard 컴포넌트를 다양한 레이아웃(사각형, 직사각형, 타임라인)으로 구현했습니다. 관련 스타일, 공통 카드 컴포넌트(BaseCard), 스토리북 구성도 함께 추가되었습니다.

# 🚀요약
- TaskCard 컴포넌트 구현
- square, rectangle, timeline 레이아웃 지원
- 카드 스타일 유틸리티(card.css) 추가
- 스토리북 테스트용 Story 작성

# 📸사진 (구현 캡처)

- rectangle
<img width="1166" height="274" alt="image" src="https://github.com/user-attachments/assets/36d4c19d-5571-42d5-b9c4-a690627c676a" />

- square
<img width="410" height="388" alt="image" src="https://github.com/user-attachments/assets/1c1def41-e782-423b-9c47-3bdfb92e2de8" />


- timeline
<img width="1590" height="332" alt="image" src="https://github.com/user-attachments/assets/9e7a8e3e-8768-4fdd-b68a-bc32209c9b5f" />


# ❗ 이런 부분을 중점으로 리뷰해주세요

- 컴포넌트 구조/레이아웃 분리에 대한 의견
- className 및 스타일 설계의 일관성
- 스토리북에서 레이아웃별 UI 렌더링 테스트 확인

# 🎸기타 (연관 이슈)

close #22 

만들면서 [이슈](https://younghoon-lee.notion.site/23964481332f80b1902ffa98db3afbaf?source=copy_link)들이 많았습니다.. 하하 기다려주셔서 감사합니다